### PR TITLE
SCMOD-15405: Updated to maven 3.8.3

### DIFF
--- a/release-notes-2.0.0.md
+++ b/release-notes-2.0.0.md
@@ -5,7 +5,7 @@ ${version-number}
 
 #### New Features
 - **SCMOD-8516**: Extend the security hardening of Java base images by disabling TLS algorithms mentioned [here](https://github.com/CAFapi/opensuse-java8-images/blob/develop/src/main/docker/disableWeakTlsAlgorithms.patch)
-- **SCMOD-14832**: Updated Maven to version [3.8.2](https://maven.apache.org/docs/3.8.2/release-notes.html).
+- **SCMOD-15405**: Updated Maven to version [3.8.3](https://maven.apache.org/docs/3.8.3/release-notes.html).
 
 #### Known Issues
 - None

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -40,8 +40,8 @@ RUN zypper -n refresh && \
     echo 6e29de1b58e17a54465d07eaa18bbde60b774bd17b1d7efcd2bc8dbbaf91c62abe8acb3933c5c27e630dc3b118453d2d0ab7fb206cf403e204708555bb0a6059 \
          /usr/share/maven/ref/settings-docker.xml | sha512sum -c - && \
     mkdir -p /usr/share/maven /usr/share/maven/ref && \
-    curl -fsSL -o /tmp/apache-maven.tar.gz https://apache.osuosl.org/maven/maven-3/3.8.2/binaries/apache-maven-3.8.2-bin.tar.gz && \
-    echo b0bf39460348b2d8eae1c861ced6c3e8a077b6e761fb3d4669be5de09490521a74db294cf031b0775b2dfcd57bd82246e42ce10904063ef8e3806222e686f222 \
+    curl -fsSL -o /tmp/apache-maven.tar.gz https://apache.osuosl.org/maven/maven-3/3.8.3/binaries/apache-maven-3.8.3-bin.tar.gz && \
+    echo 1c12a5df43421795054874fd54bb8b37d242949133b5bf6052a063a13a93f13a20e6e9dae2b3d85b9c7034ec977bbc2b6e7f66832182b9c863711d78bfe60faa \
          /tmp/apache-maven.tar.gz | sha512sum -c - && \
     tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 && \
     rm -f /tmp/apache-maven.tar.gz && \


### PR DESCRIPTION
Maven 3.8.2 does not appear to be available anymore: https://apache.osuosl.org/maven/maven-3/

It looks like they only store the latest minor release on that page so as 3.8.3 is the latest 3.8 release that is the only one available. There is an archive page here: https://archive.apache.org/dist/maven/maven-3/
We could use that instead but they say its not recommended. The issue is that the main page is going to be a moving target and if we are happy with that then its fine, otherwise if we want static we should use the archive page.